### PR TITLE
Fixed clock setting for f091 devices

### DIFF
--- a/source/system_stm32f0xx.c
+++ b/source/system_stm32f0xx.c
@@ -452,7 +452,7 @@ uint8_t SetSysClock_PLL_HSI(void)
   RCC_OscInitStruct.HSIState       = RCC_HSI_ON;
   RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_ON;
   RCC_OscInitStruct.PLL.PLLSource  = RCC_PLLSOURCE_HSI; // HSI div 2
-  RCC_OscInitStruct.PLL.PREDIV     = RCC_PREDIV_DIV1;
+  RCC_OscInitStruct.PLL.PREDIV     = RCC_PREDIV_DIV2;
   RCC_OscInitStruct.PLL.PLLMUL     = RCC_PLL_MUL12;
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
       return 0; // FAIL


### PR DESCRIPTION
The original code created a configuration of 8MHz_12/1 (96MHz), corrected is now 8MHz_12/2 (48MHz).
